### PR TITLE
fix cascades on dedicated servers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,7 @@ fabric_version=0.83.0+1.20
 owo_version=0.11.2+1.20
 sushi_version=0.1.1
 seasons_version=2.2.1+1.20
+
+# modrinth access token
+# it's existence is required to download dependencies
+modrinth_token="PLACE_YOUR_TOKEN_HERE"

--- a/src/main/java/com/chailotl/particular/mixin/InjectFlowableFluid.java
+++ b/src/main/java/com/chailotl/particular/mixin/InjectFlowableFluid.java
@@ -1,22 +1,23 @@
 package com.chailotl.particular.mixin;
 
 import com.chailotl.particular.Main;
-import net.minecraft.fluid.FlowableFluid;
 import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.WaterFluid;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.random.Random;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-@Mixin(FlowableFluid.class)
+@Mixin(WaterFluid.class)
 public class InjectFlowableFluid
 {
 	@Inject(
-		method = "onScheduledTick",
+		method = "randomDisplayTick",
 		at = @At("TAIL"))
-	protected void spawnCascades(World world, BlockPos pos, FluidState state, CallbackInfo ci)
+	protected void spawnCascades(World world, BlockPos pos, FluidState state, Random random, CallbackInfo ci)
 	{
 		if (!Main.CONFIG.cascades()) { return; }
 


### PR DESCRIPTION
The method `onScheduledTick` is only called every tick on local servers.

**NOTE**: this uses a method from the `WaterFluid` class, not the `FlowableFluid` class. This should not change anything, since all checks, e.g. the cascade strength check, tests against water anyway, but I'm not familiar with this, so I may be wrong.