### PR TITLE
Quick 1.21.4 port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.8-SNAPSHOT'
+	id 'fabric-loom' version '1.9-SNAPSHOT'
 	id 'maven-publish'
 	id "me.modmuss50.mod-publish-plugin" version "0.5.1"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.parallel=true
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.21.3
-yarn_mappings=1.21.3+build.2
+minecraft_version=1.21.4
+yarn_mappings=1.21.4+build.4
 loader_version=0.16.9
 
 # Mod Properties
@@ -15,7 +15,7 @@ maven_group=com.chailotl.particular
 archives_base_name=particular
 
 # Dependencies
-fabric_version=0.107.3+1.21.3
-owo_version=0.12.16+1.21.2
+fabric_version=0.113.0+1.21.4
+owo_version=0.12.19+1.21.4
 sushi_version=0.2.1+1.21
 seasons_version=2.2.1+1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ loader_version=0.16.9
 
 # Mod Properties
 mod_name=Particular
-mod_version=1.1.1+1.21.3
+mod_version=1.1.1+1.21.4
 maven_group=com.chailotl.particular
 archives_base_name=particular
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/chailotl/particular/Main.java
+++ b/src/main/java/com/chailotl/particular/Main.java
@@ -49,8 +49,8 @@ public class Main implements ClientModInitializer
 
 	private static Map<Block, LeafData> leavesData = new HashMap<>(Map.of(
 		Blocks.OAK_LEAVES, new LeafData(Particles.OAK_LEAF),
-		Blocks.BIRCH_LEAVES, new LeafData(Particles.BIRCH_LEAF, new Color(FoliageColors.getBirchColor())),
-		Blocks.SPRUCE_LEAVES, new LeafData(Particles.SPRUCE_LEAF, new Color(FoliageColors.getSpruceColor())),
+		Blocks.BIRCH_LEAVES, new LeafData(Particles.BIRCH_LEAF, new Color(FoliageColors.BIRCH)),
+		Blocks.SPRUCE_LEAVES, new LeafData(Particles.SPRUCE_LEAF, new Color(FoliageColors.BIRCH)),
 		Blocks.JUNGLE_LEAVES, new LeafData(Particles.JUNGLE_LEAF),
 		Blocks.ACACIA_LEAVES, new LeafData(Particles.ACACIA_LEAF),
 		Blocks.DARK_OAK_LEAVES, new LeafData(Particles.DARK_OAK_LEAF),

--- a/src/main/java/com/chailotl/particular/Main.java
+++ b/src/main/java/com/chailotl/particular/Main.java
@@ -57,7 +57,7 @@ public class Main implements ClientModInitializer
 		// Populate leaves data
 		leavesData.put(Blocks.OAK_LEAVES, new LeafData(Particles.OAK_LEAF));
 		leavesData.put(Blocks.BIRCH_LEAVES, new LeafData(Particles.BIRCH_LEAF, new Color(FoliageColors.BIRCH)));
-		leavesData.put(Blocks.SPRUCE_LEAVES, new LeafData(Particles.SPRUCE_LEAF, new Color(FoliageColors.BIRCH)));
+		leavesData.put(Blocks.SPRUCE_LEAVES, new LeafData(Particles.SPRUCE_LEAF, new Color(FoliageColors.SPRUCE)));
 		leavesData.put(Blocks.JUNGLE_LEAVES, new LeafData(Particles.JUNGLE_LEAF));
 		leavesData.put(Blocks.ACACIA_LEAVES, new LeafData(Particles.ACACIA_LEAF));
 		leavesData.put(Blocks.DARK_OAK_LEAVES, new LeafData(Particles.DARK_OAK_LEAF));

--- a/src/main/java/com/chailotl/particular/Main.java
+++ b/src/main/java/com/chailotl/particular/Main.java
@@ -47,23 +47,25 @@ public class Main implements ClientModInitializer
 	public static ConcurrentHashMap<BlockPos, Integer> cascades = new ConcurrentHashMap<>();
 	private static float fireflyFrequency = 1f;
 
-	private static Map<Block, LeafData> leavesData = new HashMap<>(Map.of(
-		Blocks.OAK_LEAVES, new LeafData(Particles.OAK_LEAF),
-		Blocks.BIRCH_LEAVES, new LeafData(Particles.BIRCH_LEAF, new Color(FoliageColors.BIRCH)),
-		Blocks.SPRUCE_LEAVES, new LeafData(Particles.SPRUCE_LEAF, new Color(FoliageColors.BIRCH)),
-		Blocks.JUNGLE_LEAVES, new LeafData(Particles.JUNGLE_LEAF),
-		Blocks.ACACIA_LEAVES, new LeafData(Particles.ACACIA_LEAF),
-		Blocks.DARK_OAK_LEAVES, new LeafData(Particles.DARK_OAK_LEAF),
-		Blocks.AZALEA_LEAVES, new LeafData(Particles.AZALEA_LEAF, Color.white),
-		Blocks.FLOWERING_AZALEA_LEAVES, new LeafData(Particles.AZALEA_LEAF, Color.white),
-		Blocks.MANGROVE_LEAVES, new LeafData(Particles.MANGROVE_LEAF),
-		Blocks.CHERRY_LEAVES, new LeafData(null)
-	));
+	private static Map<Block, LeafData> leavesData = new HashMap<>();
 
 	@Override
 	public void onInitializeClient()
 	{
 		LOGGER.info("I am quite particular about the effects I choose to add :3");
+
+		// Populate leaves data
+		leavesData.put(Blocks.OAK_LEAVES, new LeafData(Particles.OAK_LEAF));
+		leavesData.put(Blocks.BIRCH_LEAVES, new LeafData(Particles.BIRCH_LEAF, new Color(FoliageColors.BIRCH)));
+		leavesData.put(Blocks.SPRUCE_LEAVES, new LeafData(Particles.SPRUCE_LEAF, new Color(FoliageColors.BIRCH)));
+		leavesData.put(Blocks.JUNGLE_LEAVES, new LeafData(Particles.JUNGLE_LEAF));
+		leavesData.put(Blocks.ACACIA_LEAVES, new LeafData(Particles.ACACIA_LEAF));
+		leavesData.put(Blocks.DARK_OAK_LEAVES, new LeafData(Particles.DARK_OAK_LEAF));
+		leavesData.put(Blocks.AZALEA_LEAVES, new LeafData(Particles.AZALEA_LEAF, Color.white));
+		leavesData.put(Blocks.FLOWERING_AZALEA_LEAVES, new LeafData(Particles.AZALEA_LEAF, Color.white));
+		leavesData.put(Blocks.MANGROVE_LEAVES, new LeafData(Particles.MANGROVE_LEAF));
+		leavesData.put(Blocks.CHERRY_LEAVES, new LeafData(null));
+		leavesData.put(Blocks.PALE_OAK_LEAVES, new LeafData(null));
 
 		// Register
 		Particles.register();

--- a/src/main/java/com/chailotl/particular/particles/WaterRippleParticle.java
+++ b/src/main/java/com/chailotl/particular/particles/WaterRippleParticle.java
@@ -48,7 +48,7 @@ public class WaterRippleParticle extends SpriteBillboardParticle
 	}
 
 	@Override
-	public void buildGeometry(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
+	public void render(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
 	{
 		Vec3d vec3d = camera.getPos();
 		float f = (float)(MathHelper.lerp(tickDelta, prevPosX, x) - vec3d.getX());

--- a/src/main/java/com/chailotl/particular/particles/leaves/LeafParticle.java
+++ b/src/main/java/com/chailotl/particular/particles/leaves/LeafParticle.java
@@ -5,9 +5,7 @@ import com.chailotl.particular.Particles;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.particle.*;
-import net.minecraft.client.render.BufferBuilder;
 import net.minecraft.client.render.Camera;
-import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.fluid.FluidState;
@@ -133,7 +131,7 @@ public class LeafParticle extends SpriteBillboardParticle
 	}
 
 	@Override
-	public void buildGeometry(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
+	public void render(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
 	{
 		Vec3d vec3d = camera.getPos();
 		float f = (float)(MathHelper.lerp(tickDelta, prevPosX, x) - vec3d.getX());

--- a/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashEmitterParticle.java
+++ b/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashEmitterParticle.java
@@ -29,9 +29,9 @@ public class WaterSplashEmitterParticle extends NoRenderParticle
 		this.width = width;
 		this.height = (speed / 2f + width / 3f);
 
-		clientWorld.addParticle(Particles.WATER_SPLASH, true, true, x, y, z, width, this.height, 0);
-		clientWorld.addParticle(Particles.WATER_SPLASH_FOAM, true, true, x, y, z, width, this.height, 0);
-		clientWorld.addParticle(Particles.WATER_SPLASH_RING, true, true, x, y, z, width, 0, 0);
+		clientWorld.addParticle(Particles.WATER_SPLASH, x, y, z, width, this.height, 0);
+		clientWorld.addParticle(Particles.WATER_SPLASH_FOAM, x, y, z, width, this.height, 0);
+		clientWorld.addParticle(Particles.WATER_SPLASH_RING, x, y, z, width, 0, 0);
 
 		if (speed > 0.5)
 		{
@@ -50,9 +50,9 @@ public class WaterSplashEmitterParticle extends NoRenderParticle
 
 		if (age == 8)
 		{
-			world.addParticle(Particles.WATER_SPLASH, true, true, x, y, z, width * 0.66f, height * 2f, 0);
-			world.addParticle(Particles.WATER_SPLASH_FOAM, true, true, x, y, z, width * 0.66f, height * 2f, 0);
-			world.addParticle(Particles.WATER_SPLASH_RING, true, true, x, y, z, width * 0.66f, 0, 0);
+			world.addParticle(Particles.WATER_SPLASH, x, y, z, width * 0.66f, height * 2f, 0);
+			world.addParticle(Particles.WATER_SPLASH_FOAM, x, y, z, width * 0.66f, height * 2f, 0);
+			world.addParticle(Particles.WATER_SPLASH_RING, x, y, z, width * 0.66f, 0, 0);
 			splash(width * 0.66f, (3f/8f + speed * 1/8f) + (width / 6f), 0.05f);
 		}
 

--- a/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashEmitterParticle.java
+++ b/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashEmitterParticle.java
@@ -29,9 +29,9 @@ public class WaterSplashEmitterParticle extends NoRenderParticle
 		this.width = width;
 		this.height = (speed / 2f + width / 3f);
 
-		clientWorld.addParticle(Particles.WATER_SPLASH, true, x, y, z, width, this.height, 0);
-		clientWorld.addParticle(Particles.WATER_SPLASH_FOAM, true, x, y, z, width, this.height, 0);
-		clientWorld.addParticle(Particles.WATER_SPLASH_RING, true, x, y, z, width, 0, 0);
+		clientWorld.addParticle(Particles.WATER_SPLASH, true, true, x, y, z, width, this.height, 0);
+		clientWorld.addParticle(Particles.WATER_SPLASH_FOAM, true, true, x, y, z, width, this.height, 0);
+		clientWorld.addParticle(Particles.WATER_SPLASH_RING, true, true, x, y, z, width, 0, 0);
 
 		if (speed > 0.5)
 		{
@@ -50,9 +50,9 @@ public class WaterSplashEmitterParticle extends NoRenderParticle
 
 		if (age == 8)
 		{
-			world.addParticle(Particles.WATER_SPLASH, true, x, y, z, width * 0.66f, height * 2f, 0);
-			world.addParticle(Particles.WATER_SPLASH_FOAM, true, x, y, z, width * 0.66f, height * 2f, 0);
-			world.addParticle(Particles.WATER_SPLASH_RING, true, x, y, z, width * 0.66f, 0, 0);
+			world.addParticle(Particles.WATER_SPLASH, true, true, x, y, z, width * 0.66f, height * 2f, 0);
+			world.addParticle(Particles.WATER_SPLASH_FOAM, true, true, x, y, z, width * 0.66f, height * 2f, 0);
+			world.addParticle(Particles.WATER_SPLASH_RING, true, true, x, y, z, width * 0.66f, 0, 0);
 			splash(width * 0.66f, (3f/8f + speed * 1/8f) + (width / 6f), 0.05f);
 		}
 

--- a/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashParticle.java
+++ b/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashParticle.java
@@ -60,7 +60,7 @@ public class WaterSplashParticle extends SpriteBillboardParticle
 	}
 
 	@Override
-	public void buildGeometry(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
+	public void render(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
 	{
 		Vec3d vec3d = camera.getPos();
 		float f = (float)(MathHelper.lerp(tickDelta, prevPosX, x) - vec3d.getX());

--- a/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashRingParticle.java
+++ b/src/main/java/com/chailotl/particular/particles/splashes/WaterSplashRingParticle.java
@@ -48,7 +48,7 @@ public class WaterSplashRingParticle extends SpriteBillboardParticle
 	}
 
 	@Override
-	public void buildGeometry(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
+	public void render(VertexConsumer vertexConsumer, Camera camera, float tickDelta)
 	{
 		Vec3d vec3d = camera.getPos();
 		float f = (float) (MathHelper.lerp(tickDelta, prevPosX, x) - vec3d.getX());


### PR DESCRIPTION
- Since `Map.of()` can accept at most 10 KV entries, and pale oak leaves are the 11th entry, the `leavesData` map is now populated in the `onInitializeClient()` method by adding each KV entry one by one. `LeafData` for the pale oak leaves is set to `null` to prevent Particular from spawning any leaf particles on them since vanilla already has leaf particles for them, much like cherry blossom leaves.
- The `addParticle` method no longer requires the `force` boolean parameter. Particular always set it to `true` previously, but that was redundant anyways since the relevant particles are declared with the `alwaysSpawn` parameter set to `true`.